### PR TITLE
Add support for C++17 emplace_back and _front

### DIFF
--- a/plf_list.h
+++ b/plf_list.h
@@ -1970,8 +1970,23 @@ public:
 			}
 		}
 
+		#if __cplusplus >= 201703L
+		template<typename... arguments>
+		inline PLF_LIST_FORCE_INLINE reference emplace_back(arguments &&... parameters)
+		{
+			emplace(end_iterator, std::forward<arguments>(parameters)...);
+			return back();
+		}
 
 
+
+		template<typename... arguments>
+		inline PLF_LIST_FORCE_INLINE reference emplace_front(arguments &&... parameters)
+		{
+			emplace(begin_iterator, std::forward<arguments>(parameters)...);
+			return front();
+		}
+		#else
 		template<typename... arguments>
 		inline PLF_LIST_FORCE_INLINE void emplace_back(arguments &&... parameters)
 		{
@@ -1985,7 +2000,7 @@ public:
 		{
 			emplace(begin_iterator, std::forward<arguments>(parameters)...);
 		}
-
+		#endif
 
 	#endif
 


### PR DESCRIPTION
When compiled with C++17 or later standard, plf::list now returns
reference from emplace_back and emplace_front in line with std::list.

No change for older standards.