### PR TITLE
Fix wrong emplace_back and _front returns

### DIFF
--- a/plf_list.h
+++ b/plf_list.h
@@ -1981,7 +1981,7 @@ public:
 		template<typename... arguments>
 		inline PLF_LIST_FORCE_INLINE reference emplace_back(arguments &&... parameters)
 		{
-			return &*(emplace(end_iterator, std::forward<arguments>(parameters)...));
+			return *(emplace(end_iterator, std::forward<arguments>(parameters)...));
 		}
 
 
@@ -1989,7 +1989,7 @@ public:
 		template<typename... arguments>
 		inline PLF_LIST_FORCE_INLINE reference emplace_front(arguments &&... parameters)
 		{
-			return &*(emplace(begin_iterator, std::forward<arguments>(parameters)...));
+			return *(emplace(begin_iterator, std::forward<arguments>(parameters)...));
 		}
 
 


### PR DESCRIPTION
Iterators were dereferenced and then extraneosly referenced again on
return from emplace_back and emplace_front. This commit ommits the
needless reference which caused code to not compile.