### PR TITLE
Make iterator types trivially copyable

### DIFF
--- a/plf_list.h
+++ b/plf_list.h
@@ -3529,7 +3529,7 @@ public:
 	{
 	private:
 		typedef typename list::node_pointer_type node_pointer_type;
-		node_pointer_type node_pointer;
+		node_pointer_type node_pointer{ NULL };
 
 	public:
 		struct list_iterator_tag {};
@@ -3623,11 +3623,11 @@ public:
 
 
 
-		list_iterator() PLF_NOEXCEPT: node_pointer(NULL) {}
+		list_iterator() PLF_NOEXCEPT = default;
 
 
 
-		list_iterator(const list_iterator &source) PLF_NOEXCEPT: node_pointer(source.node_pointer) {}
+		list_iterator(const list_iterator &source) PLF_NOEXCEPT = default;
 
 
 
@@ -3640,11 +3640,7 @@ public:
 
 
 
-		list_iterator & operator = (const list_iterator &rh) PLF_NOEXCEPT
-		{
-			node_pointer = rh.node_pointer;
-			return *this;
-		}
+		list_iterator & operator = (const list_iterator &rh) PLF_NOEXCEPT = default;
 
 
 
@@ -3662,7 +3658,7 @@ public:
 
 
 		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
-			list_iterator (list_iterator &&source) PLF_NOEXCEPT: node_pointer(std::move(source.node_pointer)) {}
+			list_iterator (list_iterator &&source) PLF_NOEXCEPT = default;
 
 
 
@@ -3675,12 +3671,7 @@ public:
 
 
 
-			list_iterator & operator = (list_iterator &&rh) PLF_NOEXCEPT
-			{
-				assert (&rh != this);
-				node_pointer = std::move(rh.node_pointer);
-				return *this;
-			}
+			list_iterator & operator = (list_iterator &&rh) PLF_NOEXCEPT = default;
 
 
 
@@ -3710,7 +3701,7 @@ public:
 	{
 	private:
 		typedef typename list::node_pointer_type node_pointer_type;
-		node_pointer_type node_pointer;
+		node_pointer_type node_pointer{NULL};
 
 	public:
 		typedef std::bidirectional_iterator_tag 	iterator_concept;
@@ -3808,11 +3799,11 @@ public:
 
 
 
-		list_reverse_iterator() PLF_NOEXCEPT: node_pointer(NULL) {}
+		list_reverse_iterator() PLF_NOEXCEPT = default;
 
 
 
-		list_reverse_iterator(const list_reverse_iterator &source) PLF_NOEXCEPT: node_pointer(source.node_pointer) {}
+		list_reverse_iterator(const list_reverse_iterator &source) PLF_NOEXCEPT = default;
 
 
 
@@ -3827,11 +3818,7 @@ public:
 
 
 
-		list_reverse_iterator& operator = (const list_reverse_iterator &source) PLF_NOEXCEPT
-		{
-			node_pointer = source.node_pointer;
-			return *this;
-		}
+		list_reverse_iterator& operator = (const list_reverse_iterator &source) PLF_NOEXCEPT = default;
 
 
 
@@ -3876,9 +3863,7 @@ public:
 
 
 		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
-			list_reverse_iterator (list_reverse_iterator &&source) PLF_NOEXCEPT:
-				node_pointer(std::move(source.node_pointer))
-			{}
+			list_reverse_iterator (list_reverse_iterator &&source) PLF_NOEXCEPT = default;
 
 
 
@@ -3893,12 +3878,7 @@ public:
 
 
 
-			list_reverse_iterator& operator = (list_reverse_iterator &&source) PLF_NOEXCEPT
-			{
-				assert (&source != this);
-				node_pointer = std::move(source.node_pointer);
-				return *this;
-			}
+			list_reverse_iterator& operator = (list_reverse_iterator &&source) PLF_NOEXCEPT = default;
 
 
 

--- a/plf_list_test_suite.cpp
+++ b/plf_list_test_suite.cpp
@@ -2134,6 +2134,29 @@ int main()
 			bug.shrink_to_fit(); // Shouldn't crash here
 		}
 
+		#ifndef PLF_TYPE_TRAITS_SUPPORT
+		{
+			title2("Trivially copyable iterators tests");
+
+			{
+				using list_type = plf::list<small_struct_non_trivial>;
+				failpass("Non-trivial iterators", std::is_trivially_copyable_v< list_type::iterator >);
+				failpass("Non-trivial const_iterators", std::is_trivially_copyable_v< list_type::const_iterator >);
+
+				failpass("Non-trivial reverse_iterators", std::is_trivially_copyable_v< list_type::reverse_iterator >);
+				failpass("Non-trivial reverse_const_iterators", std::is_trivially_copyable_v< list_type::const_reverse_iterator >);
+			}
+
+			{
+				using list_type = plf::list<int>;
+				failpass("Trivial iterators", std::is_trivially_copyable_v< list_type::iterator >);
+				failpass("Trivial const_iterators", std::is_trivially_copyable_v< list_type::const_iterator >);
+
+				failpass("Trivial reverse_iterators", std::is_trivially_copyable_v< list_type::reverse_iterator >);
+				failpass("Trivial reverse_const_iterators", std::is_trivially_copyable_v< list_type::const_reverse_iterator >);
+			}
+		}
+		#endif
 
 	}
 


### PR DESCRIPTION
Ensure that iterator types don't prevent containing types from being trivially copyable.
This is important when iterators are used as data members in other structures, using them must not affect trivially-copyable property of containing type.

This is particularly beneficial for open-addressing hash maps such as `absl::flat_hash_map<K, V, ...>` or `boost::unordered::unordered_flat_map<K, V, ...>`. The value `V` type of the hash map should better be lightweight because with flat maps (Swiss Table, Robin Hood, etc.) move values around in memory during resizing and rehashing. Trivially copyable types minimize performance penalties during these operations, allowing the container to use optimized memcpy-based moves instead of element-wise copying.

This commit allows using iterators in value types of hash maps and not preventing optimizations based on trivially copyable property.